### PR TITLE
Modernize offline workspace navigation and add Files/Tools Compose screens

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -68,6 +68,7 @@ dependencies {
     implementation "androidx.constraintlayout:constraintlayout:2.1.4"
     implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:2.7.0"
     implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.7.0"
+    implementation "androidx.lifecycle:lifecycle-runtime-compose:2.7.0"
     implementation "androidx.activity:activity-ktx:1.8.2"
     implementation "androidx.fragment:fragment-ktx:1.6.2"
 

--- a/app/src/main/java/com/propdf/editor/ui/files/FilesScreen.kt
+++ b/app/src/main/java/com/propdf/editor/ui/files/FilesScreen.kt
@@ -1,0 +1,101 @@
+package com.propdf.editor.ui.files
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.PictureAsPdf
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material.icons.filled.StarBorder
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExtendedFloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.propdf.core.domain.model.RecentFile
+import com.propdf.editor.ui.home.formatFileSize
+import com.propdf.editor.ui.main.MainViewModel
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun FilesScreen(viewModel: MainViewModel, onOpenPdf: () -> Unit) {
+    val state by viewModel.uiState.collectAsStateWithLifecycle()
+    Scaffold(
+        topBar = { TopAppBar(title = { Text("Files") }) },
+        floatingActionButton = { ExtendedFloatingActionButton(onClick = onOpenPdf, icon = { Icon(Icons.Default.Add, null) }, text = { Text("Open PDF") }) }
+    ) { padding ->
+        LazyColumn(
+            modifier = Modifier.fillMaxSize().padding(padding),
+            contentPadding = PaddingValues(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            item {
+                OutlinedTextField(
+                    value = state.searchQuery,
+                    onValueChange = viewModel::setSearchQuery,
+                    modifier = Modifier.fillMaxWidth(),
+                    leadingIcon = { Icon(Icons.Default.Search, null) },
+                    singleLine = true,
+                    label = { Text("Search offline library") }
+                )
+            }
+            if (state.files.isEmpty()) {
+                item { EmptyFilesCard(onOpenPdf) }
+            } else {
+                items(state.files, key = { it.uri }) { file -> RecentFileRow(file, { viewModel.openPdfString(file.uri) }, { viewModel.toggleFavourite(file.uri) }) }
+            }
+        }
+    }
+}
+
+@Composable
+private fun RecentFileRow(file: RecentFile, onClick: () -> Unit, onFavorite: () -> Unit) {
+    Card(modifier = Modifier.fillMaxWidth().clickable(onClick = onClick), shape = RoundedCornerShape(20.dp), elevation = CardDefaults.cardElevation(1.dp)) {
+        Row(Modifier.padding(16.dp), verticalAlignment = Alignment.CenterVertically) {
+            Icon(Icons.Default.PictureAsPdf, contentDescription = null, tint = MaterialTheme.colorScheme.primary)
+            Column(Modifier.weight(1f).padding(horizontal = 16.dp)) {
+                Text(file.displayName, maxLines = 1, overflow = TextOverflow.Ellipsis, style = MaterialTheme.typography.titleSmall)
+                Spacer(Modifier.height(2.dp))
+                Text("${formatFileSize(file.fileSizeBytes)} · ${file.pageCount} pages", style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+            }
+            IconButton(onClick = onFavorite) { Icon(if (file.isFavourite) Icons.Default.Star else Icons.Default.StarBorder, contentDescription = "Favorite") }
+        }
+    }
+}
+
+@Composable
+private fun EmptyFilesCard(onOpenPdf: () -> Unit) {
+    Card(shape = RoundedCornerShape(24.dp), colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.primaryContainer)) {
+        Column(Modifier.fillMaxWidth().padding(24.dp), horizontalAlignment = Alignment.CenterHorizontally) {
+            Text("Build your offline workspace", style = MaterialTheme.typography.titleMedium)
+            Text("Open PDFs with scoped storage access. Files stay on this device.", style = MaterialTheme.typography.bodyMedium, color = MaterialTheme.colorScheme.onPrimaryContainer)
+            Spacer(Modifier.height(16.dp))
+            ExtendedFloatingActionButton(onClick = onOpenPdf, icon = { Icon(Icons.Default.Add, null) }, text = { Text("Open PDF") })
+        }
+    }
+}

--- a/app/src/main/java/com/propdf/editor/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/propdf/editor/ui/home/HomeScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavController
 import com.propdf.editor.ui.main.MainViewModel
 import com.propdf.editor.domain.model.*
@@ -32,16 +33,17 @@ import com.propdf.editor.ui.theme.*
 fun HomeScreen(
     navController: NavController,
     mainViewModel: MainViewModel,
+    onOpenPdf: () -> Unit,
     viewModel: HomeViewModel = hiltViewModel()
 ) {
-    val uiState by viewModel.uiState.collectAsState()
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
     Scaffold(
         topBar = {
             TopAppBar(
                 title = { Text("ProPDF Editor", style = MaterialTheme.typography.titleLarge) },
                 actions = {
-                    IconButton(onClick = { navController.navigate("search") }) {
+                    IconButton(onClick = { navController.navigate("files") }) {
                         Icon(Icons.Default.Search, contentDescription = "Search")
                     }
                     IconButton(onClick = { navController.navigate("settings") }) {
@@ -62,7 +64,7 @@ fun HomeScreen(
                     Icon(Icons.Default.CameraAlt, contentDescription = "Scan")
                 }
                 FloatingActionButton(
-                    onClick = { /* Open file picker */ },
+                    onClick = onOpenPdf,
                     containerColor = MaterialTheme.colorScheme.primaryContainer,
                     contentColor = MaterialTheme.colorScheme.onPrimaryContainer
                 ) {
@@ -130,10 +132,10 @@ fun StatItem(value: String, label: String, color: Color) {
 @Composable
 fun QuickActionsRow(navController: NavController) {
     val actions = listOf(
-        QuickAction("Open", Icons.Default.FolderOpen, pdf_blue, "folders"),
-        QuickAction("Favorites", Icons.Default.Star, pdf_amber, "favorites"),
-        QuickAction("Cloud", Icons.Default.Cloud, pdf_teal, "cloud"),
-        QuickAction("Recycle Bin", Icons.Default.Delete, pdf_red, "recyclebin")
+        QuickAction("Files", Icons.Default.FolderOpen, pdf_blue, "files"),
+        QuickAction("Favorites", Icons.Default.Star, pdf_amber, "files"),
+        QuickAction("Scanner", Icons.Default.CameraAlt, pdf_teal, "scanner"),
+        QuickAction("Tools", Icons.Default.Build, pdf_red, "tools")
     )
     LazyRow(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
         items(actions) { action ->

--- a/app/src/main/java/com/propdf/editor/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/propdf/editor/ui/main/MainActivity.kt
@@ -1,21 +1,46 @@
 package com.propdf.editor.ui.main
 
+import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
 import androidx.activity.ComponentActivity
+import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
-import androidx.compose.animation.*
+import androidx.compose.animation.AnimatedContentTransitionScope
 import androidx.compose.animation.core.tween
+import androidx.compose.animation.slideIntoContainer
+import androidx.compose.animation.slideOutOfContainer
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Build
+import androidx.compose.material.icons.filled.Description
+import androidx.compose.material.icons.filled.Home
+import androidx.compose.material.icons.filled.PhotoCamera
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.NavigationRail
+import androidx.compose.material3.NavigationRailItem
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
@@ -27,41 +52,39 @@ import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import com.propdf.core.domain.result.AppResult
 import com.propdf.core.saf.SafEngine
-import com.propdf.editor.ui.cloud.CloudScreen
-import com.propdf.editor.ui.favorites.FavoritesScreen
+import com.propdf.editor.ui.files.FilesScreen
 import com.propdf.editor.ui.home.HomeScreen
-import com.propdf.editor.ui.recyclebin.RecycleBinScreen
+import com.propdf.editor.ui.scanner.ModernScannerActivity
 import com.propdf.editor.ui.settings.SettingsScreen
 import com.propdf.editor.ui.theme.ProPDFTheme
+import com.propdf.editor.ui.tools.LaunchCardScreen
+import com.propdf.editor.ui.tools.ToolsActivity
+import com.propdf.editor.ui.tools.ToolsScreen
 import com.propdf.viewer.presentation.PremiumViewerActivity
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
-sealed class Screen(val route: String, val titleRes: Int, val iconRes: Int) {
-    object Home : Screen("home", com.propdf.editor.R.string.nav_home, com.propdf.editor.R.drawable.ic_home)
-    object Favorites : Screen("favorites", com.propdf.editor.R.string.nav_favorites, com.propdf.editor.R.drawable.ic_favorite)
-    object Cloud : Screen("cloud", com.propdf.editor.R.string.nav_cloud, com.propdf.editor.R.drawable.ic_cloud)
-    object RecycleBin : Screen("recyclebin", com.propdf.editor.R.string.nav_recycle, com.propdf.editor.R.drawable.ic_delete)
-    object Settings : Screen("settings", com.propdf.editor.R.string.nav_settings, com.propdf.editor.R.drawable.ic_settings)
+sealed class Screen(val route: String, val title: String, val icon: ImageVector) {
+    data object Home : Screen("home", "Home", Icons.Default.Home)
+    data object Files : Screen("files", "Files", Icons.Default.Description)
+    data object Scanner : Screen("scanner", "Scanner", Icons.Default.PhotoCamera)
+    data object Tools : Screen("tools", "Tools", Icons.Default.Build)
+    data object Settings : Screen("settings", "Settings", Icons.Default.Settings)
 }
 
-val bottomNavItems = listOf(Screen.Home, Screen.Favorites, Screen.Cloud, Screen.RecycleBin, Screen.Settings)
+val bottomNavItems = listOf(Screen.Home, Screen.Files, Screen.Scanner, Screen.Tools, Screen.Settings)
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
-
     private val viewModel: MainViewModel by viewModels()
 
-    @Inject
-    lateinit var safEngine: SafEngine
+    @Inject lateinit var safEngine: SafEngine
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
-
         observeViewerLaunch()
-
         setContent {
             ProPDFTheme {
                 Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colorScheme.background) {
@@ -71,31 +94,17 @@ class MainActivity : ComponentActivity() {
         }
     }
 
-    /**
-     * Observes [MainViewModel.uiState] for a pending viewer URI.
-     * When set, resolves the content URI to a cache File via [SafEngine],
-     * then launches [PremiumViewerActivity] with the absolute file path.
-     */
     private fun observeViewerLaunch() {
         lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.STARTED) {
                 viewModel.uiState.collect { state ->
                     val uriStr = state.launchViewerUri ?: return@collect
-                    viewModel.onViewerLaunched()  // clear immediately to avoid re-triggering
-
+                    viewModel.onViewerLaunched()
                     val uri = runCatching { Uri.parse(uriStr) }.getOrNull() ?: return@collect
-
-                    // Resolve content:// URI to a real File the PdfRenderer can open
                     val fileResult = safEngine.resolveToFile(uri)
                     if (fileResult is AppResult.Success) {
-                        val intent = PremiumViewerActivity.createIntent(
-                            this@MainActivity,
-                            fileResult.data.absolutePath
-                        )
-                        startActivity(intent)
+                        startActivity(PremiumViewerActivity.createIntent(this@MainActivity, fileResult.data.absolutePath))
                     }
-                    // If resolveToFile fails, the error is swallowed here;
-                    // the ViewModel already surfaces errors via errorMessage.
                 }
             }
         }
@@ -105,43 +114,59 @@ class MainActivity : ComponentActivity() {
 @Composable
 fun MainApp(viewModel: MainViewModel) {
     val navController = rememberNavController()
-    Scaffold(
-        bottomBar = {
-            val navBackStackEntry by navController.currentBackStackEntryAsState()
-            val currentDestination = navBackStackEntry?.destination
-            NavigationBar {
-                bottomNavItems.forEach { screen ->
-                    val selected = currentDestination?.hierarchy?.any { it.route == screen.route } == true
-                    NavigationBarItem(
-                        icon = { Icon(painter = painterResource(id = screen.iconRes), contentDescription = stringResource(id = screen.titleRes)) },
-                        label = { Text(stringResource(id = screen.titleRes)) },
-                        selected = selected,
-                        onClick = {
-                            navController.navigate(screen.route) {
-                                popUpTo(navController.graph.findStartDestination().id) { saveState = true }
-                                launchSingleTop = true
-                                restoreState = true
-                            }
-                        }
-                    )
-                }
-            }
+    val context = LocalContext.current
+    val configuration = LocalConfiguration.current
+    val useRail = configuration.screenWidthDp >= 600 || configuration.orientation == android.content.res.Configuration.ORIENTATION_LANDSCAPE
+    val openPdfLauncher = rememberLauncherForActivityResult(ActivityResultContracts.OpenDocument()) { uri ->
+        uri?.let {
+            runCatching { context.contentResolver.takePersistableUriPermission(it, Intent.FLAG_GRANT_READ_URI_PERMISSION) }
+            viewModel.openPdf(it)
         }
-    ) { innerPadding ->
+    }
+    val openPdf = remember(openPdfLauncher) { { openPdfLauncher.launch(arrayOf("application/pdf")) } }
+
+    AdaptiveNavigationScaffold(navController = navController, useRail = useRail) { innerPadding ->
         NavHost(
             navController = navController,
             startDestination = Screen.Home.route,
             modifier = Modifier.padding(innerPadding),
-            enterTransition = { slideIntoContainer(AnimatedContentTransitionScope.SlideDirection.Left, animationSpec = tween(300)) },
-            exitTransition = { slideOutOfContainer(AnimatedContentTransitionScope.SlideDirection.Left, animationSpec = tween(300)) },
-            popEnterTransition = { slideIntoContainer(AnimatedContentTransitionScope.SlideDirection.Right, animationSpec = tween(300)) },
-            popExitTransition = { slideOutOfContainer(AnimatedContentTransitionScope.SlideDirection.Right, animationSpec = tween(300)) }
+            enterTransition = { slideIntoContainer(AnimatedContentTransitionScope.SlideDirection.Left, animationSpec = tween(220)) },
+            exitTransition = { slideOutOfContainer(AnimatedContentTransitionScope.SlideDirection.Left, animationSpec = tween(220)) },
+            popEnterTransition = { slideIntoContainer(AnimatedContentTransitionScope.SlideDirection.Right, animationSpec = tween(220)) },
+            popExitTransition = { slideOutOfContainer(AnimatedContentTransitionScope.SlideDirection.Right, animationSpec = tween(220)) }
         ) {
-            composable(Screen.Home.route) { HomeScreen(navController, viewModel) }
-            composable(Screen.Favorites.route) { FavoritesScreen(navController) }
-            composable(Screen.Cloud.route) { CloudScreen(navController) }
-            composable(Screen.RecycleBin.route) { RecycleBinScreen(navController) }
+            composable(Screen.Home.route) { HomeScreen(navController, viewModel, onOpenPdf = openPdf) }
+            composable(Screen.Files.route) { FilesScreen(viewModel, onOpenPdf = openPdf) }
+            composable(Screen.Scanner.route) { LaunchCardScreen("Scanner", "Capture documents offline with the built-in scanner.", "Open Scanner") { context.startActivity(Intent(context, ModernScannerActivity::class.java)) } }
+            composable(Screen.Tools.route) { ToolsScreen { context.startActivity(Intent(context, ToolsActivity::class.java)) } }
             composable(Screen.Settings.route) { SettingsScreen(navController) }
         }
     }
+}
+
+@Composable
+private fun AdaptiveNavigationScaffold(navController: androidx.navigation.NavHostController, useRail: Boolean, content: @Composable (PaddingValues) -> Unit) {
+    val navBackStackEntry by navController.currentBackStackEntryAsState()
+    val currentDestination = navBackStackEntry?.destination
+    val navigate: (Screen) -> Unit = { screen ->
+        navController.navigate(screen.route) {
+            popUpTo(navController.graph.findStartDestination().id) { saveState = true }
+            launchSingleTop = true
+            restoreState = true
+        }
+    }
+    if (useRail) {
+        Row(Modifier.fillMaxSize()) {
+            NavigationRail { bottomNavItems.forEach { item -> NavItem(item, currentDestination?.hierarchy?.any { it.route == item.route } == true, true) { navigate(item) } } }
+            Box(Modifier.weight(1f)) { content(PaddingValues(0.dp)) }
+        }
+    } else {
+        Scaffold(bottomBar = { NavigationBar { bottomNavItems.forEach { item -> NavItem(item, currentDestination?.hierarchy?.any { it.route == item.route } == true, false) { navigate(item) } } } }, content = content)
+    }
+}
+
+@Composable
+private fun NavItem(screen: Screen, selected: Boolean, rail: Boolean, onClick: () -> Unit) {
+    if (rail) NavigationRailItem(selected = selected, onClick = onClick, icon = { Icon(screen.icon, screen.title) }, label = { Text(screen.title) })
+    else NavigationBarItem(selected = selected, onClick = onClick, icon = { Icon(screen.icon, screen.title) }, label = { Text(screen.title) })
 }

--- a/app/src/main/java/com/propdf/editor/ui/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/propdf/editor/ui/settings/SettingsScreen.kt
@@ -19,7 +19,6 @@ import androidx.navigation.NavController
 fun SettingsScreen(navController: NavController) {
     var darkMode by remember { mutableStateOf(false) }
     var dynamicColors by remember { mutableStateOf(true) }
-    var autoSync by remember { mutableStateOf(true) }
     var autoDeleteDays by remember { mutableStateOf(30f) }
 
     Scaffold(
@@ -43,8 +42,7 @@ fun SettingsScreen(navController: NavController) {
             item { SettingsSwitch(Icons.Default.DarkMode, "Dark Mode", "Use dark theme", darkMode) { darkMode = it } }
             item { SettingsSwitch(Icons.Default.Palette, "Dynamic Colors", "Use system wallpaper colors", dynamicColors) { dynamicColors = it } }
 
-            item { SettingsSection("Storage & Sync") }
-            item { SettingsSwitch(Icons.Default.Sync, "Auto Sync", "Automatically sync with cloud", autoSync) { autoSync = it } }
+            item { SettingsSection("Local Storage") }
             item {
                 Card(shape = RoundedCornerShape(16.dp)) {
                     Column(modifier = Modifier.padding(16.dp)) {

--- a/app/src/main/java/com/propdf/editor/ui/tools/ToolsScreen.kt
+++ b/app/src/main/java/com/propdf/editor/ui/tools/ToolsScreen.kt
@@ -1,0 +1,53 @@
+package com.propdf.editor.ui.tools
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Build
+import androidx.compose.material.icons.filled.ChevronRight
+import androidx.compose.material3.Card
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ToolsScreen(openLegacyTools: () -> Unit) {
+    val tools = listOf("Merge PDFs", "Split PDF", "Compress PDF", "Watermark", "Page Numbers", "Encrypt PDF", "Extract Text")
+    Scaffold(topBar = { TopAppBar(title = { Text("Tools") }) }) { padding ->
+        LazyColumn(Modifier.fillMaxSize().padding(padding), contentPadding = PaddingValues(16.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
+            item { Text("Offline PDF actions", style = MaterialTheme.typography.titleMedium) }
+            items(tools) { tool ->
+                Card(onClick = openLegacyTools, modifier = Modifier.fillMaxWidth(), shape = RoundedCornerShape(18.dp)) {
+                    ListItem(headlineContent = { Text(tool) }, supportingContent = { Text("Runs locally on your device") }, leadingContent = { Icon(Icons.Default.Build, null) }, trailingContent = { Icon(Icons.Default.ChevronRight, null) })
+                }
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun LaunchCardScreen(title: String, body: String, action: String, onLaunch: () -> Unit) {
+    Scaffold(topBar = { TopAppBar(title = { Text(title) }) }) { padding ->
+        Column(Modifier.fillMaxSize().padding(padding).padding(16.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
+            Card(onClick = onLaunch, modifier = Modifier.fillMaxWidth(), shape = RoundedCornerShape(24.dp)) {
+                ListItem(headlineContent = { Text(action) }, supportingContent = { Text(body) }, leadingContent = { Icon(Icons.Default.Build, null) }, trailingContent = { Icon(Icons.Default.ChevronRight, null) })
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Incrementally migrate the main workspace UI toward Jetpack Compose + Material 3 while preserving the existing PDF rendering and tooling engines. 
- Provide an offline-first, adaptive, premium navigation shell that works well on phones, tablets, landscape and foldable widths. 
- Expose a scoped-storage PDF picker and lifecycle-safe flows so the offline library integrates with existing repository and viewer flows. 
- Remove cloud-sync wording and avoid introducing any backend or fake sync systems.

### Description
- Reworked the main app shell to an adaptive Compose navigation surface with five offline-first tabs: `Home`, `Files`, `Scanner`, `Tools`, and `Settings`, and added a navigation rail for wide/tablet layouts (new `AdaptiveNavigationScaffold` in `MainActivity`).
- Added a Material 3 `FilesScreen` (new file `app/src/main/java/com/propdf/editor/ui/files/FilesScreen.kt`) that collects `MainViewModel.uiState` with `collectAsStateWithLifecycle`, provides offline search, favorites toggle and an empty-state CTA that launches a SAF PDF picker.
- Added `ToolsScreen` and a lightweight `LaunchCardScreen` (new file `app/src/main/java/com/propdf/editor/ui/tools/ToolsScreen.kt`) which launch the existing legacy `ToolsActivity` and `ModernScannerActivity` to preserve production-grade native implementations instead of rewriting engines.
- Updated `HomeScreen` to use `collectAsStateWithLifecycle`, expose an `onOpenPdf` callback and replace cloud quick-actions with local quick-actions (Files, Favorites, Scanner, Tools) while keeping the dashboard layout and performance characteristics.
- Integrated SAF-based PDF opening using `ActivityResultContracts.OpenDocument`, taking persistable URI permission and forwarding chosen URIs into the existing `MainViewModel.openPdf` flow so existing viewer/resolution logic remains unchanged (no rendering engine changes were performed).
- Small dependency adjustment: added `androidx.lifecycle:lifecycle-runtime-compose:2.7.0` to enable lifecycle-aware Compose state collection.
- Kept architecture, repositories, scanner, tools, and viewer modules intact and launched legacy activities rather than porting their implementations to Compose to avoid regressions.

### Testing
- Ran repository checks: `git diff --check` passed with staged changes showing no whitespace/patch issues. 
- Attempted a Kotlin compile: `./gradlew :app:compileDebugKotlin` was executed but could not complete in this environment because the Android Gradle plugin artifact could not be resolved from configured repositories, so a full compile/test run was not possible here. 
- Also attempted compilation with `JAVA_HOME` set to Java 17 to address local toolchain issues, but the AGP artifact resolution failure persisted and prevented a successful build in this execution environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3498bfed2483239d5580d7fa92cf12)