### PR TITLE
Fix startup crash and harden app initialization

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -15,7 +15,7 @@
         android:required="false" />
 
     <application
-        android:name=".ProPDFApplication"
+        android:name=".ProPDFApp"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"

--- a/app/src/main/java/com/propdf/editor/MainActivity.kt
+++ b/app/src/main/java/com/propdf/editor/MainActivity.kt
@@ -331,7 +331,7 @@ class MainActivity : AppCompatActivity() {
     private fun shareFile(file: File) {
         try {
             val uri = androidx.core.content.FileProvider.getUriForFile(
-                this, "$packageName.provider", file
+                this, "$packageName.fileprovider", file
             )
             startActivity(Intent.createChooser(Intent(Intent.ACTION_SEND).apply {
                 type = "application/pdf"

--- a/app/src/main/java/com/propdf/editor/ProPDFApp.kt
+++ b/app/src/main/java/com/propdf/editor/ProPDFApp.kt
@@ -17,6 +17,7 @@ import com.propdf.editor.core.pool.BitmapPool
 import com.propdf.editor.worker.CleanupWorker
 import com.tom_roush.pdfbox.android.PDFBoxResourceLoader
 import dagger.hilt.android.HiltAndroidApp
+import java.util.concurrent.Executors
 import javax.inject.Inject
 
 @HiltAndroidApp
@@ -28,20 +29,24 @@ class ProPDFApp : Application(), Configuration.Provider {
     companion object {
         private const val TAG = "ProPDFApp"
         private var initialized = false
+        private val backgroundExecutor = Executors.newSingleThreadExecutor { runnable ->
+            Thread(runnable, "propdf-startup").apply { isDaemon = true }
+        }
     }
 
     override fun onCreate() {
         // Fast startup: defer non-critical initialization
         super.onCreate()
 
-        // Critical path: PDFBox init (required before any PDF operation)
-        PDFBoxResourceLoader.init(applicationContext)
+        // Crash prevention must be installed before any optional startup work.
+        safeStartup("CrashGuard") { CrashGuard.initialize(this) }
 
-        // Crash prevention
-        CrashGuard.initialize()
+        // Critical path: PDFBox init (required before any PDF operation). Keep this
+        // non-fatal so a bad/missing PDFBox asset never blocks the Home screen.
+        safeStartup("PDFBox") { PDFBoxResourceLoader.init(applicationContext) }
 
-        // GPU capability detection
-        GpuOptimizer.initialize(this)
+        // GPU capability detection is useful but optional for first draw.
+        safeStartup("GPU optimizer") { GpuOptimizer.initialize(this) }
 
         // Restore theme (fast, no I/O blocking)
         restoreTheme()
@@ -49,17 +54,17 @@ class ProPDFApp : Application(), Configuration.Provider {
         // Defer heavy initialization to background
         if (!initialized) {
             initialized = true
-            applicationContext.mainExecutor.execute {
+            backgroundExecutor.execute {
                 initializeBackground()
             }
         }
 
         // Register memory pressure callbacks
-        registerComponentCallbacks(MemoryPressureCallbacks())
+        safeStartup("memory callbacks") { registerComponentCallbacks(MemoryPressureCallbacks()) }
 
         // Enable StrictMode in debug builds for ANR detection
         if (BuildConfig.DEBUG) {
-            enableStrictMode()
+            safeStartup("StrictMode") { enableStrictMode() }
         }
     }
 
@@ -85,15 +90,22 @@ class ProPDFApp : Application(), Configuration.Provider {
     }
 
     private fun initializeBackground() {
-        // Initialize caches (can be slow)
-        BitmapPool.getDefaultInstance()
-        LruBitmapCache.getInstance(this)
-
-        // Schedule periodic cleanup
-        CleanupWorker.schedulePeriodic(this)
-
-        // Reduce process priority for background work
         Process.setThreadPriority(Process.THREAD_PRIORITY_BACKGROUND)
+
+        safeStartup("bitmap pool") { BitmapPool.getDefaultInstance() }
+        safeStartup("bitmap cache") { LruBitmapCache.getInstance(this) }
+        safeStartup("cleanup worker") { CleanupWorker.schedulePeriodic(this) }
+    }
+
+    private fun safeStartup(name: String, block: () -> Unit) {
+        try {
+            block()
+        } catch (oom: OutOfMemoryError) {
+            Log.e(TAG, "Startup step failed because of low memory: $name", oom)
+            CrashGuard.emergencyCleanup(this)
+        } catch (throwable: Throwable) {
+            Log.e(TAG, "Startup step failed and was deferred/skipped: $name", throwable)
+        }
     }
 
     private fun enableStrictMode() {
@@ -119,7 +131,7 @@ class ProPDFApp : Application(), Configuration.Provider {
     inner class MemoryPressureCallbacks : ComponentCallbacks2 {
         override fun onTrimMemory(level: Int) {
             Log.w(TAG, "onTrimMemory level=$level")
-            LruBitmapCache.getInstance(this@ProPDFApp).trimMemory(level)
+            safeStartup("trim bitmap cache") { LruBitmapCache.getInstance(this@ProPDFApp).trimMemory(level) }
 
             when (level) {
                 ComponentCallbacks2.TRIM_MEMORY_RUNNING_CRITICAL,
@@ -137,7 +149,7 @@ class ProPDFApp : Application(), Configuration.Provider {
 
         override fun onLowMemory() {
             Log.e(TAG, "onLowMemory — emergency cleanup")
-            CrashGuard.emergencyCleanup()
+            CrashGuard.emergencyCleanup(this@ProPDFApp)
         }
     }
 }

--- a/app/src/main/java/com/propdf/editor/core/CrashGuard.kt
+++ b/app/src/main/java/com/propdf/editor/core/CrashGuard.kt
@@ -28,13 +28,13 @@ object CrashGuard {
     /**
      * Initialize crash guards. Call from Application.onCreate()
      */
-    fun initialize() {
+    fun initialize(context: android.content.Context? = null) {
         // Set default uncaught exception handler
         val defaultHandler = Thread.getDefaultUncaughtExceptionHandler()
         Thread.setDefaultUncaughtExceptionHandler { thread, throwable ->
             Log.e(TAG, "FATAL: Uncaught exception on ${thread.name}", throwable)
             // Attempt graceful cleanup before crash
-            emergencyCleanup()
+            emergencyCleanup(context)
             defaultHandler?.uncaughtException(thread, throwable)
         }
 
@@ -104,17 +104,21 @@ object CrashGuard {
      * Emergency cleanup under memory pressure.
      * Clears all caches, triggers GC, reduces process priority.
      */
-    fun emergencyCleanup() {
+    fun emergencyCleanup(context: android.content.Context? = null) {
         Log.w(TAG, "EMERGENCY CLEANUP triggered")
 
         // Reduce priority to let system reclaim memory
         Process.setThreadPriority(Process.THREAD_PRIORITY_BACKGROUND)
 
-        // Clear all static caches
-        com.propdf.editor.core.cache.LruBitmapCache.getInstance(
-            android.app.Application()
-        ).clear()
-        com.propdf.editor.core.pool.BitmapPool.getDefaultInstance().clear()
+        // Clear all static caches. Disk-backed caches need a real app Context; using
+        // a synthetic Application here can crash before the real failure is logged.
+        context?.applicationContext?.let { appContext ->
+            runCatching {
+                com.propdf.editor.core.cache.LruBitmapCache.getInstance(appContext).clear()
+            }.onFailure { Log.w(TAG, "Unable to clear bitmap cache during emergency cleanup", it) }
+        }
+        runCatching { com.propdf.editor.core.pool.BitmapPool.getDefaultInstance().clear() }
+            .onFailure { Log.w(TAG, "Unable to clear bitmap pool during emergency cleanup", it) }
 
         // Suggest GC
         System.gc()

--- a/app/src/main/java/com/propdf/editor/ui/tools/ToolsActivity.kt
+++ b/app/src/main/java/com/propdf/editor/ui/tools/ToolsActivity.kt
@@ -510,7 +510,7 @@ class ToolsActivity : AppCompatActivity() {
         val f = need() ?: return
         try {
             val uri = androidx.core.content.FileProvider.getUriForFile(
-                this, "$packageName.provider", f
+                this, "$packageName.fileprovider", f
             )
             startActivity(Intent.createChooser(Intent(Intent.ACTION_SEND).apply {
                 type = "application/pdf"
@@ -600,7 +600,7 @@ class ToolsActivity : AppCompatActivity() {
                 .setPositiveButton("Open") { _, _ ->
                     val openUri = try {
                         androidx.core.content.FileProvider.getUriForFile(
-                            this@ToolsActivity, "$packageName.provider", fileForOpen
+                            this@ToolsActivity, "$packageName.fileprovider", fileForOpen
                         )
                     } catch (_: Exception) { Uri.fromFile(fileForOpen) }
                     ViewerActivity.start(this@ToolsActivity, openUri)
@@ -608,7 +608,7 @@ class ToolsActivity : AppCompatActivity() {
                 .setNeutralButton("Share") { _, _ ->
                     try {
                         val uri = androidx.core.content.FileProvider.getUriForFile(
-                            this@ToolsActivity, "$packageName.provider", fileForOpen
+                            this@ToolsActivity, "$packageName.fileprovider", fileForOpen
                         )
                         startActivity(Intent.createChooser(Intent(Intent.ACTION_SEND).apply {
                             type = "application/pdf"


### PR DESCRIPTION
### Motivation
- The app crashed on startup because the manifest referenced a non-existent application class, preventing Android from instantiating the process before the Home screen could appear. 
- Several optional/heavy initialization steps ran on the startup path (PDFBox, caches, WorkManager scheduling, GPU probing) and could throw or block the main thread, making startup fragile. 
- FileProvider authority mismatches in share/open call sites risk IllegalArgumentException when producing/sharing files. 
- Crash cleanup could itself throw by using a synthetic Application context when clearing disk-backed caches.

### Description
- Corrected the manifest application class to the actual Hilt class by changing `android:name` from `.ProPDFApplication` to `.ProPDFApp` in `app/src/main/AndroidManifest.xml`.
- Hardened `ProPDFApp.onCreate()` (`app/src/main/java/com/propdf/editor/ProPDFApp.kt`) by introducing `safeStartup(name, block)` to run optional startup steps under try/catch, moving deferred heavy initialization to a single background thread executor, and avoiding running deferred init on the main executor.
- Made `CrashGuard` safer (`app/src/main/java/com/propdf/editor/core/CrashGuard.kt`) by accepting an optional real `Context` on `initialize()` and `emergencyCleanup(context)` and protecting disk-backed cache clear operations with `runCatching` so cleanup does not cause new crashes.
- Unified FileProvider authority usage by replacing legacy `"$packageName.provider"` calls with the manifest-authority `"$packageName.fileprovider"` in `ToolsActivity` and `MainActivity` to match `android:authorities="${applicationId}.fileprovider"`.
- Files modified: `app/src/main/AndroidManifest.xml`, `app/src/main/java/com/propdf/editor/ProPDFApp.kt`, `app/src/main/java/com/propdf/editor/core/CrashGuard.kt`, `app/src/main/java/com/propdf/editor/ui/tools/ToolsActivity.kt`, `app/src/main/java/com/propdf/editor/MainActivity.kt`.

### Testing
- Code diff/style check (`diff --check`) was executed and passed for the modified files.
- Attempted to run a debug assemble (`./gradlew :app:assembleDebug`) but the build in this environment failed due to a host JDK compatibility issue (installed Java 25 / class file major version 69) which prevents Gradle/Groovy from parsing project scripts; therefore a full build/test run could not be completed here.
- Static inspections and project-wide searches were run to confirm no remaining references to the old application name or the old provider authority; those inspections completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a67f2517a488323bee822a00f0cfbe2)