### PR TITLE
Repair startup and primary navigation wiring

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -15,7 +15,7 @@
         android:required="false" />
 
     <application
-        android:name=".ProPDFApplication"
+        android:name=".ProPDFApp"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"

--- a/app/src/main/java/com/propdf/editor/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/propdf/editor/ui/main/MainActivity.kt
@@ -19,12 +19,28 @@ import androidx.lifecycle.repeatOnLifecycle
 import com.propdf.editor.ui.navigation.ProPDFNavigation
 import com.propdf.editor.ui.navigation.TabletNavigation
 import com.propdf.editor.ui.theme.ProPDFTheme
+import com.propdf.editor.ui.viewer.ViewerActivity
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
+
+    private companion object {
+        val SUPPORTED_OPEN_MIME_TYPES = arrayOf(
+            "application/pdf",
+            "image/*",
+            "text/plain",
+            "text/html",
+            "application/msword",
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            "application/vnd.ms-excel",
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            "application/vnd.ms-powerpoint",
+            "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+        )
+    }
 
     val viewModel: MainViewModel by viewModels()
     private var isReady by mutableStateOf(false)
@@ -64,7 +80,10 @@ class MainActivity : ComponentActivity() {
                 if (isTablet) {
                     TabletNavigation(mainViewModel = viewModel)
                 } else {
-                    ProPDFNavigation(mainViewModel = viewModel)
+                    ProPDFNavigation(
+                        mainViewModel = viewModel,
+                        onOpenPdf = { pdfPicker.launch(SUPPORTED_OPEN_MIME_TYPES) }
+                    )
                 }
             }
         }
@@ -72,7 +91,12 @@ class MainActivity : ComponentActivity() {
         lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.STARTED) {
                 viewModel.uiState.collectLatest { state ->
-                    if (state.launchViewerUri != null) {
+                    state.launchViewerUri?.let { uriString ->
+                        ViewerActivity.start(
+                            this@MainActivity,
+                            Uri.parse(uriString),
+                            displayName = null
+                        )
                         viewModel.onViewerLaunched()
                     }
                     isReady = true

--- a/app/src/main/java/com/propdf/editor/ui/navigation/ProPDFNavigation.kt
+++ b/app/src/main/java/com/propdf/editor/ui/navigation/ProPDFNavigation.kt
@@ -8,17 +8,23 @@ import androidx.compose.material.icons.filled.*
 import androidx.compose.material.icons.outlined.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
+import android.content.Intent
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
+import com.propdf.editor.ui.files.FilesScreen
 import com.propdf.editor.ui.home.HomeScreen
 import com.propdf.editor.ui.main.MainViewModel
+import com.propdf.editor.ui.scanner.DocumentScannerActivity
+import com.propdf.editor.ui.search.SearchScreen
 import com.propdf.editor.ui.settings.SettingsScreen
+import com.propdf.editor.ui.tools.ToolsScreen
 import com.propdf.editor.ui.viewer.PdfViewerScreen
 
 sealed class Screen(
@@ -37,13 +43,15 @@ sealed class Screen(
 @Composable
 fun ProPDFNavigation(
     mainViewModel: MainViewModel,
-    navController: NavHostController = rememberNavController()
+    navController: NavHostController = rememberNavController(),
+    onOpenPdf: () -> Unit = {}
 ) {
     val isTablet = LocalConfiguration.current.screenWidthDp >= 600
     val navBackStackEntry by navController.currentBackStackEntryAsState()
     val currentRoute = navBackStackEntry?.destination?.route
 
     val bottomNavItems = listOf(Screen.Home, Screen.Files, Screen.Scanner, Screen.Tools)
+    val context = LocalContext.current
 
     Scaffold(
         bottomBar = {
@@ -114,20 +122,35 @@ fun ProPDFNavigation(
                 HomeScreen(
                     navController = navController,
                     mainViewModel = mainViewModel,
-                    onOpenPdf = { /* Open PDF picker */ }
+                    onOpenPdf = onOpenPdf
                 )
             }
             composable(Screen.Files.route) {
-                // Files screen implementation
+                FilesScreen(navController = navController, mainViewModel = mainViewModel)
             }
             composable(Screen.Scanner.route) {
-                // Scanner screen implementation
+                LaunchedEffect(Unit) {
+                    context.startActivity(Intent(context, DocumentScannerActivity::class.java))
+                    navController.navigate(Screen.Home.route) { launchSingleTop = true }
+                }
+                Box(modifier = Modifier.fillMaxSize(), contentAlignment = androidx.compose.ui.Alignment.Center) {
+                    CircularProgressIndicator()
+                }
             }
             composable(Screen.Tools.route) {
-                // Tools screen implementation
+                ToolsScreen(navController = navController)
             }
             composable(Screen.Settings.route) {
                 SettingsScreen(navController = navController)
+            }
+            composable("search") {
+                SearchScreen(navController = navController, mainViewModel = mainViewModel)
+            }
+            composable("recent") {
+                FilesScreen(navController = navController, mainViewModel = mainViewModel)
+            }
+            composable("folders") {
+                FilesScreen(navController = navController, mainViewModel = mainViewModel)
             }
             composable("viewer/{fileName}") { backStackEntry ->
                 PdfViewerScreen(

--- a/docs/implementation-report.md
+++ b/docs/implementation-report.md
@@ -1,0 +1,52 @@
+# ProPDF Editor Implementation Audit
+
+Date: 2026-07-28
+
+## Scope inspected
+
+This audit reviewed the Gradle project graph, app manifest, startup classes, main Compose navigation, home entry points, file/search/tools screens, viewer entry point, scanner activity registration, module manifests, and repository/module layout.
+
+## Implemented features found
+
+- Hilt application startup exists in `ProPDFApp` with PDFBox initialization, crash guard, GPU optimization, theme restore, bitmap caches, and WorkManager configuration.
+- Compose-based `ui.main.MainActivity` exists as the launcher shell with splash screen, theme collection, SAF open-document picker, and handling for `ACTION_VIEW` PDF intents.
+- A legacy XML `MainActivity` and a modern Compose `ui.main.MainActivity` both exist, indicating duplicate main-entry implementations.
+- `ViewerActivity` provides an activity-based PDF viewer with renderer, search, annotation state, PDF operations integration, OCR manager injection, cache integration, and explicit `start` helper.
+- File, search, settings, tools, scanner, conversion, OCR, forms, security, recent, favorites, recycle bin, and document manager UI classes exist.
+- Core repositories and databases exist for recent files, OCR jobs, compression, search, forms, document metadata, collections, tags, signatures, storage access, sync, and NAS.
+- Android Storage Access Framework helper/repository code exists in core/storage modules.
+- CameraX dependencies and scanner activities exist.
+- ML Kit on-device text recognition dependency and OCR workers/managers exist.
+
+## Partially implemented or disconnected features
+
+- The manifest pointed at a non-existent application class (`.ProPDFApplication`) while the Hilt application class is `ProPDFApp`; this prevents correct startup and dependency injection.
+- The Home screen's primary add/open PDF FAB was wired to an empty lambda, so the visible Open/Add action was decorative.
+- `MainViewModel.openPdf` recorded selected/opened documents and set `launchViewerUri`, but `ui.main.MainActivity` cleared that state without launching the viewer, so SAF selections did not actually open in the PDF viewer.
+- Main bottom-navigation routes for Files, Scanner, and Tools were placeholder comments; these tabs were reachable but empty.
+- Home action routes such as `search`, `recent`, and `folders` were referenced but not registered in the main navigation graph, which would crash when tapped.
+- Scanner navigation did not launch the registered scanner activity from the Compose navigation graph.
+- The OpenDocument picker was limited to `application/pdf`; the product requirements call for PDFs, images, Office documents, text, and HTML to be selectable.
+
+## Duplicate implementations and dead-code risks
+
+- Two main activity implementations exist: `com.propdf.editor.MainActivity` (legacy XML) and `com.propdf.editor.ui.main.MainActivity` (Compose launcher). The manifest uses the Compose launcher; the legacy activity is currently not externally reachable.
+- Multiple database classes named `AppDatabase` exist under app and core package trees. This raises DI ambiguity and migration-risk concerns.
+- Forms implementation appears duplicated between app and editor module package paths.
+- Some included modules in `settings.gradle` are not all consumed by `app/build.gradle` (for example storage/sync/nas are present in the repository but not currently app dependencies), so features in those modules may be disconnected from the runnable app.
+
+## Broken navigation found and repaired
+
+- Home Open/Add PDF now launches Android's Storage Access Framework through the existing activity-result launcher.
+- SAF selections now start `ViewerActivity` immediately after `MainViewModel` persists the recent-file record.
+- Files tab now displays the existing `FilesScreen` instead of a blank route.
+- Tools tab now displays the existing `ToolsScreen` instead of a blank route.
+- Scanner tab now launches the existing `DocumentScannerActivity` and returns the navigation shell to Home.
+- Search, Recent, and Folders routes referenced by Home now resolve to real screens rather than missing destinations.
+
+## Remaining production-readiness risks
+
+- Full compile verification is blocked in this container because Gradle 8.2 cannot run on the installed Java 25 runtime (`Unsupported class file major version 69`). A Java 17 runtime or a Gradle/AGP upgrade is required before exhaustive build validation can continue.
+- Manual Android-device verification was not possible in this non-interactive container.
+- Many advanced requested capabilities (full Office conversion, certificate-backed signing, permanent redaction, cloud-provider sync, OCR language-pack management, SD/USB OTG validation, and every PDF editing operation) require deeper feature-by-feature validation once the project can compile and run.
+- Several UI actions inside feature screens may still navigate to unregistered tool-specific routes; those need the next audit pass after build validation is unblocked.


### PR DESCRIPTION
### Motivation
- Fix app startup and navigation so the Storage Access Framework (SAF) flow opens documents in the viewer and Compose navigation entries are not placeholders or broken.

### Description
- Change the application entry to use the existing Hilt application class by updating the manifest to `android:name=".ProPDFApp"`.
- Update `MainActivity` to expose a `SUPPORTED_OPEN_MIME_TYPES` array, launch the SAF picker for broader MIME types, and start `ViewerActivity` when `MainViewModel` emits a selected URI.
- Improve the Compose navigation by adding an `onOpenPdf` callback to `ProPDFNavigation`, registering `Files`, `Tools`, `search`, `recent`, and `folders` composables, and launching `DocumentScannerActivity` from the Scanner tab instead of leaving placeholder routes.
- Add an implementation audit report at `docs/implementation-report.md` that summarizes inspected modules, found issues, repairs made, and remaining production-readiness risks.

### Testing
- Ran `git diff --check`, which passed without reported whitespace or index issues.
- Attempted `./gradlew :app:assembleDebug`, which could not complete due to an environment toolchain mismatch producing an `Unsupported class file major version 69` error from the Gradle/JVM combination, so full build verification was blocked.
- No device/emulator runtime tests were possible in this non-interactive container environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a682281d348832398d140fba51c2b39)